### PR TITLE
Fix typo bug in vasptools.sh VASP_PREPARE_INCAR

### DIFF
--- a/Execution/tasks/vasp/vasptools.sh
+++ b/Execution/tasks/vasp/vasptools.sh
@@ -465,8 +465,8 @@ function VASP_PREPARE_INCAR {
 	VASP_SET_TAG "NPAR" "1"
     fi
 
-    local MAGMOMS=$(VASP_GET_TAG MAGMOMS)
-    if [ -z "$MAGMOMS" ]; then
+    local MAGMOM=$(VASP_GET_TAG MAGMOM)
+    if [ -z "$MAGMOM" ]; then
 	LINE=$(VASP_MAGMOMLINE)
 	if [ -z "$LINE" ]; then
 	    echo "Error in VASP_PREPARE_INCAR: got empty MAGMOM line" >&2


### PR DESCRIPTION
A fix to solve issue https://github.com/httk/httk/issues/49 so that the user can set a custom value on MAGMOM without it being overwritten by a default httk set standard value.

Closes #49 