### PR TITLE
Speeding up trivial_symmetry_reduce by supplying hall symbol

### DIFF
--- a/src/httk/atomistic/spacegrouputils.py
+++ b/src/httk/atomistic/spacegrouputils.py
@@ -602,7 +602,7 @@ def reduce_by_symops(coordgroups, symopvs, hall_symbol):
     return reduced_coordgroups, wyckoff_symbols, multiplicities
 
 
-def trivial_symmetry_reduce(coordgroups):
+def trivial_symmetry_reduce(coordgroups, hall_symbol = None):
     """
     Looks for 'trivial' ways to reduce the coordinates in the given coordgroups by a standard set of symmetry operations.
     This is not a symmetry finder (and it is not intended to be), but for a standard primitive cell taken from a standard
@@ -610,26 +610,38 @@ def trivial_symmetry_reduce(coordgroups):
     """
     # TODO: Actually implement, instead of this placeholder that just gives up and returns P 1
 
-    symops = []
-    symopvs = []
-    for symop in all_symops:
-        symopv = FracVector.create(symop)
-        if check_symop(coordgroups, symopv):
-            symops += [all_symops[symop]]
-            symopvs += [symopv]
+    if hall_symbol is None:
+        symops = []
+        symopvs = []
+        for symop in all_symops:
+            symopv = FracVector.create(symop)
+            if check_symop(coordgroups, symopv):
+                symops += [all_symops[symop]]
+                symopvs += [symopv]
 
-    shash = symopshash(symops)
-    if shash in symops_hash_index:
-        hall_symbol = symops_hash_index[shash]
-        rc_reduced_coordgroups, wyckoff_symbols, multiplicities = reduce_by_symops(coordgroups, symopvs, hall_symbol)
+        shash = symopshash(symops)
+        if shash in symops_hash_index:
+            hall_symbol = symops_hash_index[shash]
+            rc_reduced_coordgroups, wyckoff_symbols, multiplicities = reduce_by_symops(coordgroups, symopvs, hall_symbol)
+            return rc_reduced_coordgroups, hall_symbol, wyckoff_symbols, multiplicities
+
+        rc_reduced_coordgroups = coordgroups
+        hall_symbol = 'P 1'
+        wyckoff_symbols = ['a']*sum([len(x) for x in coordgroups])
+        multiplicities = [1]*sum([len(x) for x in coordgroups])
+
         return rc_reduced_coordgroups, hall_symbol, wyckoff_symbols, multiplicities
 
-    rc_reduced_coordgroups = coordgroups
-    hall_symbol = 'P 1'
-    wyckoff_symbols = ['a']*sum([len(x) for x in coordgroups])
-    multiplicities = [1]*sum([len(x) for x in coordgroups])
+    elif hall_symbol == 'P 1': # shouldnt reduce_by_symops be doing exactly this for P1 ?
+        rc_reduced_coordgroups = coordgroups
+        wyckoff_symbols = ['a']*sum([len(x) for x in coordgroups])
+        multiplicities = [1]*sum([len(x) for x in coordgroups])
+        return rc_reduced_coordgroups, hall_symbol, wyckoff_symbols, multiplicities
 
-    return rc_reduced_coordgroups, hall_symbol, wyckoff_symbols, multiplicities
+    else:
+        symopvs=get_symops(hall_symbol)
+        rc_reduced_coordgroups, wyckoff_symbols, multiplicities = reduce_by_symops(coordgroups, symopvs, hall_symbol)
+        return rc_reduced_coordgroups, hall_symbol, wyckoff_symbols, multiplicities
 
 
 def main():

--- a/src/httk/atomistic/structure.py
+++ b/src/httk/atomistic/structure.py
@@ -481,8 +481,8 @@ class Structure(HttkObject):
             self._other_reps['rc'] = rc_struct
         return self._other_reps['rc']
 
-    def transform(self, matrix, max_search_cells=20, max_atoms=5000,use_hall_symbol=None):
-        return transform(self, matrix, max_search_cells=max_search_cells, max_atoms=max_atoms,use_hall_symbol=use_hall_symbol)
+    def transform(self, matrix, max_search_cells=20, max_atoms=5000,force_hall_symbol=None):
+        return transform(self, matrix, max_search_cells=max_search_cells, max_atoms=max_atoms,force_hall_symbol=force_hall_symbol)
 
 
     @httk_typed_property(str)

--- a/src/httk/atomistic/structure.py
+++ b/src/httk/atomistic/structure.py
@@ -392,8 +392,18 @@ class Structure(HttkObject):
             other_reps = {}
 
         if (rc_sites is None or rc_cell is None or hall_symbol is None):
-            new = cls.use(uc_rep)
+            transform = get_primitive_to_conventional_basis_transform(uc_rep.uc_basis)
+            newuc = uc_rep.transform(transform)
+            rc_reduced_coordgroups, hall_symbol, wyckoff_symbols, multiplicities = spacegrouputils.trivial_symmetry_reduce(newuc.uc_reduced_coordgroups,
+                                                                                                                           hall_symbol=hall_symbol)
+            new = cls.create(assignments=newuc.assignments, rc_cell=newuc.uc_cell,
+                              rc_reduced_coordgroups=rc_reduced_coordgroups,
+                              wyckoff_symbols=wyckoff_symbols,
+                              multiplicities=multiplicities,
+                              hall_symbol=hall_symbol)
+            
             new._other_reps = other_reps
+            
         else:
             new = cls(assignments=assignments, rc_sites=rc_sites, rc_cell=rc_cell, other_reps=other_reps)
 
@@ -471,8 +481,9 @@ class Structure(HttkObject):
             self._other_reps['rc'] = rc_struct
         return self._other_reps['rc']
 
-    def transform(self, matrix, max_search_cells=20, max_atoms=1000):
-        return transform(self, matrix, max_search_cells=max_search_cells, max_atoms=max_atoms)
+    def transform(self, matrix, max_search_cells=20, max_atoms=5000,use_hall_symbol=None):
+        return transform(self, matrix, max_search_cells=max_search_cells, max_atoms=max_atoms,use_hall_symbol=use_hall_symbol)
+
 
     @httk_typed_property(str)
     def hall_symbol(self):

--- a/src/httk/atomistic/structureutils.py
+++ b/src/httk/atomistic/structureutils.py
@@ -946,11 +946,11 @@ def get_primitive_basis_transform(hall_symbol):
 #     # Transform to primitive cell
 #     return lattrans
 
-def transform(structure, transformation, max_search_cells=20, max_atoms=5000, use_hall_symbol = None):
+def transform(structure, transformation, max_search_cells=20, max_atoms=5000, force_hall_symbol = None):
     """Applies a transformation matrix to the structure
 
     Args:
-        use_hall_symbol (bool, optional): Enforces a supplied hall_symbol. If True, defaults into using P 1.
+        force_hall_symbol (bool, optional): Enforces a supplied hall_symbol. If True, defaults into using P 1.
     """
     transformation = FracVector.use(transformation).simplify()
     #if transformation.denom != 1:
@@ -1002,10 +1002,10 @@ def transform(structure, transformation, max_search_cells=20, max_atoms=5000, us
         raise Exception("Very obtuse angles in cell, to search over all possible lattice vectors will take a very long time. To force, set max_search_cells = None when calling find_prototypeid()")
 
 
-    if use_hall_symbol:
-        assert isinstance(use_hall_symbol, str), "hall symbol must be a string" 
+    if force_hall_symbol:
+        assert isinstance(force_hall_symbol, str), "hall symbol must be a string" 
 
-        return structure.create(uc_reduced_coordgroups=extendedcoordgroups, uc_basis=new_cell.basis, assignments=structure.assignments,hall_symbol= use_hall_symbol)
+        return structure.create(uc_reduced_coordgroups=extendedcoordgroups, uc_basis=new_cell.basis, assignments=structure.assignments,hall_symbol= force_hall_symbol)
 
     return structure.create(uc_reduced_coordgroups=extendedcoordgroups, uc_basis=new_cell.basis, assignments=structure.assignments)
 

--- a/src/httk/atomistic/structureutils.py
+++ b/src/httk/atomistic/structureutils.py
@@ -946,8 +946,12 @@ def get_primitive_basis_transform(hall_symbol):
 #     # Transform to primitive cell
 #     return lattrans
 
-def transform(structure, transformation, max_search_cells=20, max_atoms=1000):
+def transform(structure, transformation, max_search_cells=20, max_atoms=5000, use_hall_symbol = None):
+    """Applies a transformation matrix to the structure
 
+    Args:
+        use_hall_symbol (bool, optional): Enforces a supplied hall_symbol. If True, defaults into using P 1.
+    """
     transformation = FracVector.use(transformation).simplify()
     #if transformation.denom != 1:
     #    raise Exception("Structure.transform requires integer transformation matrix")
@@ -962,7 +966,7 @@ def transform(structure, transformation, max_search_cells=20, max_atoms=1000):
     #print("SEEK_COUNTS",seek_counts, volume_ratio, structure.uc_counts, transformation)
     total_seek_counts = sum(seek_counts)
     if total_seek_counts > max_atoms:
-        raise Exception("Structure.transform: more than "+str(max_atoms)+" needed. Change limit with max_atoms parameter.")
+        raise Exception("Structure.transform: more than "+str(max_atoms)+" needed, given "+str(total_seek_counts)+". Change limit with max_atoms parameter.")
 
     #if max_search_cells != None and maxvec[0]*maxvec[1]*maxvec[2] > max_search_cells:
     #    raise Exception("Very obtuse angles in cell, to search over all possible lattice vectors will take a very long time. To force, set max_search_cells = None when calling find_prototypeid()")
@@ -996,6 +1000,12 @@ def transform(structure, transformation, max_search_cells=20, max_atoms=1000):
             break
     else:
         raise Exception("Very obtuse angles in cell, to search over all possible lattice vectors will take a very long time. To force, set max_search_cells = None when calling find_prototypeid()")
+
+
+    if use_hall_symbol:
+        assert isinstance(use_hall_symbol, str), "hall symbol must be a string" 
+
+        return structure.create(uc_reduced_coordgroups=extendedcoordgroups, uc_basis=new_cell.basis, assignments=structure.assignments,hall_symbol= use_hall_symbol)
 
     return structure.create(uc_reduced_coordgroups=extendedcoordgroups, uc_basis=new_cell.basis, assignments=structure.assignments)
 

--- a/src/httk/atomistic/unitcellstructure.py
+++ b/src/httk/atomistic/unitcellstructure.py
@@ -327,7 +327,7 @@ class UnitcellStructure(HttkObject):
     def uc_counts(self):
         return self.uc_sites.counts
 
-    def transform(self, matrix, max_search_cells=20, max_atoms=1000):
+    def transform(self, matrix, max_search_cells=20, max_atoms=5000):
         return transform(self, matrix, max_search_cells=max_search_cells, max_atoms=max_atoms)
 
     def __str__(self):


### PR DESCRIPTION
* hall symbols are allowed to propagate through `transform` methods using `use_hall_symbol` keyword.
* default `max_atoms` parameter increased to 5000
* all relevant tests passed