### PR TITLE
updates documentation on force_hall_symbol.

### DIFF
--- a/src/httk/atomistic/structureutils.py
+++ b/src/httk/atomistic/structureutils.py
@@ -950,7 +950,7 @@ def transform(structure, transformation, max_search_cells=20, max_atoms=10000, f
     """Applies a transformation matrix to the structure
 
     Args:
-        force_hall_symbol (bool, optional): Enforces a supplied hall_symbol. If True, defaults into using P 1.
+        force_hall_symbol (str, optional): Enforces a supplied hall_symbol.
     """
     transformation = FracVector.use(transformation).simplify()
     #if transformation.denom != 1:


### PR DESCRIPTION
There is a bit of utility in mapping True to use hall symbol 'P 1', as it is a bit difficult to validate which hall symbol format one should use (i.e, with or without spaces etc.), and almost always one uses this feature to default to P1.