### PR TITLE
Update config.py to work with python3.12

### DIFF
--- a/src/httk/config/config.py
+++ b/src/httk/config/config.py
@@ -78,7 +78,11 @@ def read_config():
             distdata_str = fp.read()
             ini_str = '[distdata]\n' + distdata_str
             ini_fp = StringIO(ini_str)
-            _config.read_file(ini_fp)
+            if not hasattr(_config,'read_file'):
+                # Python2 compatibility
+                _config.readfp(ini_fp)
+            else:
+                _config.read_file(ini_fp)
             httk_root = os.path.realpath(os.path.join(python_root,_config.get('distdata','root').strip('"')))
     except (IOError, configparser.NoSectionError, configparser.NoOptionError):
         httk_root = os.path.realpath(os.path.join(python_root,_default_httk_root))

--- a/src/httk/config/config.py
+++ b/src/httk/config/config.py
@@ -78,7 +78,7 @@ def read_config():
             distdata_str = fp.read()
             ini_str = '[distdata]\n' + distdata_str
             ini_fp = StringIO(ini_str)
-            _config.readfp(ini_fp)
+            _config.read_file(ini_fp)
             httk_root = os.path.realpath(os.path.join(python_root,_config.get('distdata','root').strip('"')))
     except (IOError, configparser.NoSectionError, configparser.NoOptionError):
         httk_root = os.path.realpath(os.path.join(python_root,_default_httk_root))


### PR DESCRIPTION
Updated ConfigParser.readfp() to ConfigParser.read_file()

readfp() was deprecated in python3.2 and completely removed in python3.12.
read_file() was introduced as a replacement in python3.2.

https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read_file