### PR TITLE
Compatibility to isotropy 7.1.6

### DIFF
--- a/Execution/computer-templates/local/command
+++ b/Execution/computer-templates/local/command
@@ -11,5 +11,6 @@ if [ -e "$SCRIPT_PATH/config.$QUEUE" ]; then
     . "$SCRIPT_PATH/config.$QUEUE"
 fi
 
+mkdir -p "${LOCAL_HTTK_DIR/#\~/$HOME}/Runs/$QUEUE/"
 cd "${LOCAL_HTTK_DIR/#\~/$HOME}/Runs/$QUEUE/"
 eval "$@"

--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ setup(
     #
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['six'],  # Optional
+    #install_requires=['peppercorn'],  # Optional
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"

--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ setup(
     #
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    #install_requires=['peppercorn'],  # Optional
+    install_requires=['six'],  # Optional
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"

--- a/src/httk/atomistic/atomisticio/structure_cif_io.py
+++ b/src/httk/atomistic/atomisticio/structure_cif_io.py
@@ -351,12 +351,13 @@ def cifdata_to_struct(cifdata, debug=False):
     if 'atom_site_symmetry_multiplicity' in element:
         multiplicities = [int(x) for x in element['atom_site_symmetry_multiplicity']]
 
-    for atom in range(len(element['atom_site_label'])):
+    symbol_reference = 'atom_site_type_symbol' if 'atom_site_type_symbol' in element else 'atom_site_label'
+    for atom in range(len(element[symbol_reference])):
         if 'atom_site_occupancy' in element:
             ratio = element['atom_site_occupancy'][atom]
         else:
             ratio = 1
-        symbol = str(re.match('[A-Z][a-z]?',element['atom_site_label'][atom]).group(0))
+        symbol = str(re.match('[A-Z][a-z]?',element[symbol_reference][atom]).group(0))
 
         occup = {'atom': periodictable.atomic_number(symbol), 'ratio': FracVector.create(ratio), }
         coord = [element['atom_site_fract_x'][atom], element['atom_site_fract_y'][atom], element['atom_site_fract_z'][atom]]

--- a/src/httk/external/isotropy_ext.py
+++ b/src/httk/external/isotropy_ext.py
@@ -62,7 +62,11 @@ def isotropy(cwd, args, inputstr, timeout=30):
     #p = subprocess.Popen([cif2cell_path]+args, stdout=subprocess.PIPE,
     #                                   stderr=subprocess.PIPE, cwd=cwd)
     #print("COMMAND CIF2CELL"+str(inputstr))
-    out, err, completed = Command(os.path.join(isotropy_path, 'findsym'), args, cwd=cwd, inputstr=inputstr).run(timeout)
+    input_file = os.path.join(cwd, "findsym_input.txt")
+    with open(input_file, "w") as f:
+        f.write(inputstr.strip())
+        args.append("{}".format(input_file))
+    out, err, completed = Command(os.path.join(isotropy_path, 'findsym'), args, cwd=cwd).run(timeout)
     #print("COMMAND CIF2CELL END"+str(out))
     return out, err, completed
     #out, err = p.communicate()

--- a/src/httk/iface/isotropy_if.py
+++ b/src/httk/iface/isotropy_if.py
@@ -34,7 +34,7 @@ def reduced_coordgroups_to_input(coordgroups, cell, comment="FINDSYM input", acc
     inputstr += str(uc_nbr_atoms)+"\n"
     inputstr += " ".join([str(group+1) for group in range(0, len(coordgroups)) for i in range(0, len(coordgroups[group]))]) + "\n"
     for rows in coordgroups:
-        for row in rows:
+        for i,row in enumerate(rows):
             inputstr += "%.8f %.8f %.8f\n" % (row[0], row[1], row[2])
     return inputstr
 
@@ -42,15 +42,14 @@ def reduced_coordgroups_to_input(coordgroups, cell, comment="FINDSYM input", acc
 def struct_to_input(struct):
     inputstr = "FINDSYM input for "+struct.formula+"\n"
     # 1
-    #inputstr += "0.001\n"; #2
-    inputstr += "0.001\n"
+    inputstr += "0.001\n"; #2
     ##################################################################
     # With FINDSYM, Version 7.1, Jul 2020, lattice, atomic, and magnetic
     # accuracies have to be all given.
     # This fixes the format of the input file, but there is still the
     # "illegal seek" pipe problem.
-    # inputstr += "0.001\n"
-    # inputstr += "0.001\n"
+    inputstr += "0.001\n"
+    inputstr += "0.001\n"
     ##################################################################
     # 2
     inputstr += "2\n"  # 3
@@ -58,7 +57,7 @@ def struct_to_input(struct):
     inputstr += "2\n"  # 5
     inputstr += "P\n"  # 6
     inputstr += str(struct.uc_nbr_atoms)+"\n"
-    inputstr += " ".join([str(group+1) for group in range(0, len(struct.uc_reduced_coordgroups)) for i in range(0, len(struct.uc_reduced_coordgroups[group]))]) + "\n"
+    inputstr += " ".join([str(struct.symbols[group]) for group in range(0, len(struct.uc_reduced_coordgroups)) for i in range(0, len(struct.uc_reduced_coordgroups[group]))]) + "\n"
     for row in struct.uc_reduced_coords:
         inputstr += "%.8f %.8f %.8f\n" % (row[0], row[1], row[2])
     #print("INPUT",struct.formula,len(struct.uc_reduced_coords))
@@ -66,18 +65,25 @@ def struct_to_input(struct):
 
 
 def out_to_cif(ioa, assignments, getwyckoff=False):
+    read_data = True
 
     def cif_start(results, match):
         results['did_start'] = True
         results['on'] = True
 
     def cif_add(results, match):
+        if not read_data:
+            return
         if results['out']:
             results['out'] = False
         else:
             add_groupdata(results)
             results['cif'] += match.group(0)+"\n"
             #results['data']+=match.group(0)+"\n"
+    
+    def cif_end(results, match):
+        nonlocal read_data
+        read_data = False # This terminates further reading of the cif data, which is important because isotropy outputs some extra stuff after the cif that we don't want to read as part of the cif.
 
     def add_groupdata(results):
 
@@ -171,12 +177,13 @@ def out_to_cif(ioa, assignments, getwyckoff=False):
     results = {'on': False, 'data': '', 'cif': '', 'out': False, 'group': -1, 'groupdata': [], 'occucounts': {}, 'did_start': False, 'wyckoff': []}
     httk.basic.micro_pyawk(ioa, [
         [r'This program has bombed', None, cif_broken],
-        [r'^# CIF file$', None, cif_start],
+        [r'^# CIF file', None, cif_start],
         [r'^_symmetry_Int_Tables_number +(.*)$', None, groupnbr],
         [r'^_symmetry_space_group_name_H-M +"(([^()]+) \(origin choice ([0-9]+)\))" *$', None, hm_symbol_origin],
         [r'^_symmetry_space_group_name_H-M +"(([^()]+) \((hexagonal axes)\))" *$', None, hm_symbol_origin],
         [r'^_symmetry_space_group_name_H-M +"([^()]+)" *$', None, hm_symbol_no_origin],
         [r'^ *([^ ]+) +([^ ]+) +([^ ]+) +([^ ]+) +([0-9.-]+) +([0-9.-]+) +([0-9.-]+) +([0-9.-]+) *$', None, coords],
+        [r'^# end of cif', None, cif_end],
         [r'.*', lambda results, match: results['on'], cif_add],
     ], debug=False, results=results)
     add_groupdata(results)


### PR DESCRIPTION
Adding this pull request to show an example of how to make the isotropy/findsym interface compatible with latest version of findsym (7.1.6). Related to issue #27 

Changes include:

1. Adding three symmetry tolerances instead of one in input
3. Saving input in temporary file instead of piping to findsym
4. Adding chemical symbols to input for findsym to include in output
5. Modifying output parsing to properly include cif and not include end-of-file marker
6. Slightly generalization of structure_cif reader to allow for the atom_site_symbol_type field as opposed to assuming the atom_site_label always contains only the chemical symbol (which findsym no longer follows)

This is not meant to be a final merge, but just an initial try, which works. Edit of the cif structure reader is perhaps handled better in the isotropy-specific output parsing (but seemed more complex as a solution).