### PR TITLE
Fixed argument index error for start-taskmgr computer template

### DIFF
--- a/Execution/computer-templates/ssh-slurm/start-taskmgr
+++ b/Execution/computer-templates/ssh-slurm/start-taskmgr
@@ -11,8 +11,8 @@ if [ -e "$SCRIPT_PATH/config.$QUEUE" ]; then
     . "$SCRIPT_PATH/config.$QUEUE"
 fi
 
-if [ -n "$1" ]; then
-    NUMBER="$1"
+if [ -n "$2" ]; then
+    NUMBER="$2"
 else
     NUMBER="1"
 fi


### PR DESCRIPTION
The httk/bin/httk-tasks-start-taskmanager file calls: "$PIPEPATH/start-taskmgr" "$QUEUE" "$NUMBER"
and thus NUMBER is argument 2.

but the httk/Execution/computer-templates/ssh-slurm/start-taskmgr looks for and assigns argument 1, which is the $QUEUE.

This resulted in only one task manager being created, no matter the NUMBER input for httk-tasks-start-taskmanager.