### PR TITLE
Fixed some parsing errors in two task-manager script 

### DIFF
--- a/Execution/computer-templates/ssh-slurm/start-taskmgr
+++ b/Execution/computer-templates/ssh-slurm/start-taskmgr
@@ -13,6 +13,7 @@ fi
 
 if [ -n "$1" ]; then
     NUMBER="$1"
+    shift 1
 else
     NUMBER="1"
 fi

--- a/bin/httk-tasks-start-taskmanager
+++ b/bin/httk-tasks-start-taskmanager
@@ -27,8 +27,8 @@ if [ -z "$QUEUE" -o "$QUEUE" == "$1" ]; then
 fi
 shift 1
 
-if [ -n "$2" ]; then
-    NUMBER="$2"
+if [ -n "$1" ]; then
+    NUMBER="$1"
     shift 1
 else
   NUMBER="1"


### PR DESCRIPTION
Fixed some parsing errors in Execution/computer-tempates/ssh-slurm/start-taskmgr and bin/httk-tasks-start-taskmanager

In bin/httk-tasks-start-taskmanager, it looks for $2 instead of $1 (after a shift 1) resulting in NUMBER being 1 no matter what number argument you put in.

Execution/computer-templates/ssh-slurm/start-taskmgr lacked a shift, resulting in passing the number variable as $@ to Execution/taskmanager.sh (line 43), causing the taskmanager to crash (it goes into case * in taskmanager.sh)